### PR TITLE
alter location of artemis tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf -y install which java-1.8.0-openjdk libaio python gettext hostname iputi
 
 ENV ARTEMIS_HOME=/opt/apache-artemis-1.5.0-SNAPSHOT PATH=$ARTEMIS_HOME/bin:$PATH
 
-ADD ./apache-artemis-bin.tar.gz ./artemis-shutdown-hook/build/distributions/artemis-shutdown-hook.tar /opt/
+ADD ./build/apache-artemis-bin.tar.gz ./artemis-shutdown-hook/build/distributions/artemis-shutdown-hook.tar /opt/
 
 # Needed for bridge clustering
 # COPY ./artemis-plugin/build/libs/artemis-plugin.jar $ARTEMIS_HOME/lib


### PR DESCRIPTION
Build at present seems to put it under build dir, docker file is looking for it current dir. Unless of course I'm just running things wrong?