### PR TITLE
Use groupId for outgoing connectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM fedora:23
 
 RUN dnf -y install which java-1.8.0-openjdk libaio python gettext hostname iputils && dnf clean all -y && mkdir -p /var/run/artemis/
 
-ENV ARTEMIS_HOME=/opt/apache-artemis-1.5.0-SNAPSHOT PATH=$ARTEMIS_HOME/bin:$PATH
+ENV ARTEMIS_HOME=/opt/apache-artemis-1.6.0-SNAPSHOT PATH=$ARTEMIS_HOME/bin:$PATH
 
 ADD ./build/apache-artemis-bin.tar.gz ./artemis-shutdown-hook/build/distributions/artemis-shutdown-hook.tar /opt/
 
-COPY ./activemq-artemis/integration/activemq-amqp-connector/target/artemis-amqp-connector-1.5.0-SNAPSHOT.jar $ARTEMIS_HOME/lib
+COPY ./activemq-artemis/integration/activemq-amqp-connector/target/artemis-amqp-connector-1.6.0-SNAPSHOT.jar $ARTEMIS_HOME/lib
 
 # Needed for bridge clustering
 # COPY ./artemis-plugin/build/libs/artemis-plugin.jar $ARTEMIS_HOME/lib
@@ -24,4 +24,4 @@ EXPOSE 5673 61616
 # Needed for bridge clustering
 # EXPOSE 7800 7801 7802
 
-CMD ["/opt/apache-artemis-1.5.0-SNAPSHOT/bin/main", "/opt/apache-artemis-1.5.0-SNAPSHOT/bin/run_artemis.sh"]
+CMD ["/opt/apache-artemis-1.6.0-SNAPSHOT/bin/main", "/opt/apache-artemis-1.6.0-SNAPSHOT/bin/run_artemis.sh"]

--- a/artemis-shutdown-hook/build.gradle
+++ b/artemis-shutdown-hook/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
    ext.openshiftRestclientVersion = '5.1.0.Final'
    ext.vertxProtonVersion = '3.3.3'
-   ext.artemisVersion = '1.5.0-SNAPSHOT'
+   ext.artemisVersion = '1.6.0-SNAPSHOT'
 }
 
 apply plugin: 'java'

--- a/config_templates/broker_queue.xml
+++ b/config_templates/broker_queue.xml
@@ -9,7 +9,7 @@
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$MESSAGING_SERVICE_HOST" />
           <param key="port" value="$MESSAGING_SERVICE_PORT_INTERNAL" />
-          <param key="containerId" value="$QUEUE_NAME" />
+          <param key="groupId" value="$QUEUE_NAME" />
         </connector-service>
       </connector-services>
    </core>

--- a/config_templates/broker_topic.xml
+++ b/config_templates/broker_topic.xml
@@ -10,7 +10,7 @@
           <factory-class>org.apache.activemq.artemis.integration.amqp.AMQPConnectorServiceFactory</factory-class>
           <param key="host" value="$MESSAGING_SERVICE_HOST" />
           <param key="port" value="$MESSAGING_SERVICE_PORT_INTERNAL" />
-          <param key="containerId" value="$CONTAINER_ID" />
+          <param key="groupId" value="$TOPIC_NAME" />
         </connector-service>
       </connector-services>
    </core>


### PR DESCRIPTION
@grs This is the work done on connector side for using connection
properties. We can just leave this here until we've decided what
to do.