### PR TITLE
ensure unique container id even when not using persistent volume

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -21,7 +21,7 @@ JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom"
 function configure() {
     local instanceDir=$1
     local instanceId=$2
-    export CONTAINER_ID=$instanceId
+    export CONTAINER_ID=$HOSTNAME
     if [ ! -d "$INSTANCE" ]; then
         $ARTEMIS_HOME/bin/artemis create $instanceDir --user admin --password admin --role admin --allow-anonymous --java-options "$JAVA_OPTS"
         cp $CONFIG_TEMPLATES/broker_header.xml /tmp/broker.xml


### PR DESCRIPTION
Without this, the topic forwarder doesn't work for non-persistent volumes, as each broker serving the topic has the same container id and so they end up sharing the inter-broker subscription queues and the messages are distributed between the other instances, not given to all.